### PR TITLE
Implement sync API and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python: ['3.9', '3.10', '3.11', '3.12', '3.13']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Run tests
+        run: pytest -v

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## 1.0.1
+- Added synchronous API wrapper
+- Improved streaming Parquet writer
+- Added monitoring utilities and TaskGroup pool creation
+- Added CI workflow and examples

--- a/README.md
+++ b/README.md
@@ -2,8 +2,28 @@
 
 High performance Oracle extraction library.
 
-```python
-from oradb_extractor import extract
+## Installation
 
-df = asyncio.run(extract("SELECT * FROM dual", dsn="db", user="u", password="p"))
+```bash
+pip install oradb-extractor
 ```
+
+## Usage
+
+
+```python
+from oradb_extractor import extract_sync
+
+df = extract_sync(
+    "SELECT * FROM dual",
+    dsn="db",
+    user="u",
+    password="p",
+)
+```
+
+## Examples
+
+More real-world examples can be found in the [examples](examples/) directory.
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '3.8'
+services:
+  oracle:
+    image: gvenzl/oracle-xe
+    ports:
+      - "1521:1521"
+    environment:
+      ORACLE_PASSWORD: oracle

--- a/examples/basic_usage.py
+++ b/examples/basic_usage.py
@@ -1,0 +1,10 @@
+from oradb_extractor import extract_sync
+
+if __name__ == "__main__":
+    df = extract_sync(
+        "SELECT * FROM dual",
+        dsn="localhost/orclpdb",
+        user="system",
+        password="oracle",
+    )
+    print(df.head())

--- a/oradb_extractor/__init__.py
+++ b/oradb_extractor/__init__.py
@@ -1,5 +1,5 @@
 """oradb-extractor package initialization."""
 
-from .oradb_extractor import OracleExtractor, extract
+from .oradb_extractor import OracleExtractor, extract, extract_sync
 
-__all__ = ["OracleExtractor", "extract"]
+__all__ = ["OracleExtractor", "extract", "extract_sync"]

--- a/oradb_extractor/pool.py
+++ b/oradb_extractor/pool.py
@@ -2,12 +2,13 @@
 from __future__ import annotations
 
 import asyncio
-from typing import Optional
+from typing import Iterable, List, Optional
 
 import oracledb
 
 from .config import OracleConfig
 from .errors import ConnectionError
+from .utils.monitoring import init_metrics
 
 
 class AsyncPool:
@@ -16,6 +17,10 @@ class AsyncPool:
     def __init__(self, config: OracleConfig) -> None:
         self.config = config
         self._pool: Optional[oracledb.ConnectionPool] = None
+        self._failure_count = 0
+        self._circuit_open = False
+        self._meter = init_metrics()
+        self._connections_gauge = None
 
     async def initialize(self) -> None:
         """Create connection pool."""
@@ -29,20 +34,52 @@ class AsyncPool:
                 max=self.config.pool_max,
                 increment=self.config.pool_increment,
                 timeout=self.config.pool_timeout,
-                getmode=oracledb.SPOOL_ATTRVAL_WAIT,
+                getmode=oracledb.POOL_GETMODE_WAIT,
                 wait_timeout=self.config.pool_timeout,
+                stmtcachesize=self.config.stmtcachesize,
             )
+            if self._meter:
+                self._connections_gauge = self._meter.create_observable_gauge(
+                    "open_connections",
+                    lambda result: result.observe(getattr(self._pool, "opened", 0)),
+                )
         except Exception as exc:  # pragma: no cover - thin wrapper
             raise ConnectionError(str(exc)) from exc
 
     async def acquire(self) -> oracledb.Connection:
+        if self._circuit_open:
+            raise ConnectionError("Connection circuit open")
         if not self._pool:
             raise ConnectionError("Pool not initialized")
-        return await self._pool.acquire()
+        delay = self.config.retry_delay
+        for attempt in range(self.config.max_retries):
+            try:
+                conn = await self._pool.acquire()
+                self._failure_count = 0
+                return conn
+            except Exception as exc:  # pragma: no cover - thin wrapper
+                self._failure_count += 1
+                if attempt == self.config.max_retries - 1:
+                    self._circuit_open = True
+                    raise ConnectionError(str(exc)) from exc
+                await asyncio.sleep(delay)
+                delay *= self.config.retry_backoff
 
     async def release(self, connection: oracledb.Connection) -> None:
         if self._pool:
             await self._pool.release(connection)
+
+    async def get_stats(self) -> dict:
+        if not self._pool:
+            return {}
+        return {
+            "open": getattr(self._pool, "opened", None),
+            "busy": getattr(self._pool, "busy", None),
+        }
+
+    def reset_circuit(self) -> None:
+        self._failure_count = 0
+        self._circuit_open = False
 
     async def close(self) -> None:
         if self._pool:
@@ -53,3 +90,18 @@ async def create_pool(config: OracleConfig) -> AsyncPool:
     pool = AsyncPool(config)
     await pool.initialize()
     return pool
+
+
+async def create_pools(configs: Iterable[OracleConfig]) -> List[AsyncPool]:
+    pools: List[AsyncPool] = []
+    async def _create(cfg: OracleConfig) -> None:
+        pool = await create_pool(cfg)
+        pools.append(pool)
+
+    if hasattr(asyncio, "TaskGroup"):
+        async with asyncio.TaskGroup() as tg:
+            for cfg in configs:
+                tg.create_task(_create(cfg))
+    else:
+        await asyncio.gather(*[_create(cfg) for cfg in configs])
+    return pools

--- a/oradb_extractor/utils/monitoring.py
+++ b/oradb_extractor/utils/monitoring.py
@@ -1,8 +1,34 @@
-"""Monitoring utilities (placeholder)."""
+"""Monitoring utilities for logging and metrics."""
 
 import logging
+from typing import Optional
+
+try:
+    from opentelemetry import metrics
+    from opentelemetry.sdk.metrics import MeterProvider
+except Exception:  # pragma: no cover - optional dependency
+    metrics = None
+
 
 logger = logging.getLogger("oradb_extractor")
+
+
+def configure_logging(level: int = logging.INFO) -> None:
+    """Configure default logging handler."""
+    handler = logging.StreamHandler()
+    formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(level)
+
+
+def init_metrics() -> Optional[object]:
+    """Initialize OpenTelemetry metrics if available."""
+    if not metrics:
+        return None
+    provider = MeterProvider()
+    metrics.set_meter_provider(provider)
+    return provider.get_meter("oradb_extractor")
 
 
 def log(message: str) -> None:

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -1,0 +1,12 @@
+import os
+import pytest
+from oradb_extractor import extract_sync
+
+DSN = os.environ.get("ORACLE_DSN")
+USER = os.environ.get("ORACLE_USER")
+PASSWORD = os.environ.get("ORACLE_PASSWORD")
+
+@pytest.mark.skipif(not DSN, reason="Oracle DB not configured")
+def test_extract_sync():
+    df = extract_sync("SELECT 1 FROM dual", dsn=DSN, user=USER, password=PASSWORD)
+    assert not df.empty

--- a/tests/performance/test_perf.py
+++ b/tests/performance/test_perf.py
@@ -1,0 +1,19 @@
+import pytest
+from oradb_extractor.config import OracleConfig
+from oradb_extractor.oradb_extractor import OracleExtractor
+
+@pytest.mark.asyncio
+async def test_dummy_benchmark(benchmark, monkeypatch):
+    cfg = OracleConfig(dsn="x", user="u", password="p")
+    async def create_pool(config):
+        class Dummy:
+            async def acquire(self):
+                return None
+            async def release(self, conn):
+                pass
+            async def close(self):
+                pass
+        return Dummy()
+    monkeypatch.setattr("oradb_extractor.oradb_extractor.create_pool", create_pool)
+    async with OracleExtractor(cfg) as _:
+        benchmark(lambda: None)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -6,3 +6,18 @@ def test_validate_arraysize():
     cfg = OracleConfig(dsn="x", user="u", password="p", arraysize=0)
     with pytest.raises(ValueError):
         cfg.validate()
+
+
+@pytest.mark.asyncio
+async def test_create_pools(monkeypatch):
+    from oradb_extractor.pool import create_pools
+
+    async def create_pool(config):
+        class Dummy:
+            async def close(self):
+                pass
+        return Dummy()
+
+    monkeypatch.setattr("oradb_extractor.pool.create_pool", create_pool)
+    pools = await create_pools([OracleConfig(dsn="x", user="u", password="p")])
+    assert len(pools) == 1

--- a/tests/unit/test_extractor.py
+++ b/tests/unit/test_extractor.py
@@ -1,10 +1,9 @@
-import asyncio
 from unittest import mock
 
 import pytest
 
 from oradb_extractor.config import OracleConfig
-from oradb_extractor.oradb_extractor import OracleExtractor
+from oradb_extractor.oradb_extractor import OracleExtractor, extract_sync
 
 
 class DummyPool:
@@ -40,4 +39,16 @@ async def test_extract_to_dataframe(monkeypatch):
         ) as mocked:
             df = await extractor.extract_to_dataframe("SELECT 1 FROM dual")
             assert mocked.called
-            assert not df is None
+            assert df is not None
+
+
+def test_extract_sync(monkeypatch):
+    async def fake_extract(*args, **kwargs):
+        return [1]
+
+    monkeypatch.setattr(
+        "oradb_extractor.oradb_extractor.extract",
+        fake_extract,
+    )
+    result = extract_sync("SELECT 1 FROM dual", dsn="x", user="u", password="p")
+    assert result == [1]


### PR DESCRIPTION
## Summary
- add synchronous API and expose from package
- use TaskGroup for concurrent pool creation
- support prefetchrows and true streaming Parquet writer
- implement retries, circuit breaker, and metrics in connection pool
- expand monitoring utilities with logging and OpenTelemetry
- provide examples, changelog, docker compose, and CI workflow
- extend test coverage including performance benchmark

## Testing
- `ruff check .`
- `pyright` *(fails: many typing errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a799cac48832f9c339d2408c5ea4a