### PR TITLE
Switch to cx_Oracle

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.0.0"
 description = "High-performance Oracle database extraction library"
 requires-python = ">=3.9"
 dependencies = [
-    "oracledb>=2.0.0",
+    "cx_Oracle>=8.3",
     "pandas>=2.0.0",
     "pyarrow>=14.0.0",
     "aiofiles>=23.0.0",


### PR DESCRIPTION
## Summary
- use cx_Oracle instead of oracledb for connections
- adapt async pool and streaming extractor to call synchronous cx_Oracle APIs via `asyncio.to_thread`
- update dependencies

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c4476be74832fa3acd2251b296b99